### PR TITLE
update

### DIFF
--- a/CMD/CMD.csproj
+++ b/CMD/CMD.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="FluentCommandLineParser" Version="1.4.3" />
-    <PackageReference Include="mzLib" Version="1.0.426" />
+    <PackageReference Include="mzLib" Version="1.0.428" />
     <PackageReference Include="Nett" Version="0.8.0" />
     <PackageReference Include="SharpLearning.Common.Interfaces" Version="0.26.9" />
     <PackageReference Include="SharpLearning.Containers" Version="0.26.9" />

--- a/EngineLayer/EngineLayer.csproj
+++ b/EngineLayer/EngineLayer.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="mzLib" Version="1.0.426" />
+    <PackageReference Include="mzLib" Version="1.0.428" />
     <PackageReference Include="Nett" Version="0.8.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.1" />
     <PackageReference Include="SharpLearning.Common.Interfaces" Version="0.26.9" />

--- a/EngineLayer/NonSpecificEnzymeSearch/NonSpecificEnzymeSearchEngine.cs
+++ b/EngineLayer/NonSpecificEnzymeSearch/NonSpecificEnzymeSearchEngine.cs
@@ -229,7 +229,7 @@ namespace EngineLayer.NonSpecificEnzymeSearch
             }
 
             //if the theoretical and experimental have the same mass or a terminal mod exists
-            if (peptide.BaseSequence.Length > localminPeptideLength)
+            if (peptide.BaseSequence.Length >= localminPeptideLength)
             {
                 double totalMass = peptide.MonoisotopicMass;// + Constants.ProtonMass;
                 int notch = searchMode.Accepts(scanPrecursorMass, totalMass);

--- a/GUI/GUI.csproj
+++ b/GUI/GUI.csproj
@@ -75,34 +75,34 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Chemistry, Version=1.0.0.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\mzLib.1.0.426\lib\net471\Chemistry.dll</HintPath>
+      <HintPath>..\packages\mzLib.1.0.428\lib\net471\Chemistry.dll</HintPath>
     </Reference>
     <Reference Include="FlashLFQ, Version=1.0.0.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\mzLib.1.0.426\lib\net471\FlashLFQ.dll</HintPath>
+      <HintPath>..\packages\mzLib.1.0.428\lib\net471\FlashLFQ.dll</HintPath>
     </Reference>
     <Reference Include="itextsharp, Version=5.5.13.0, Culture=neutral, PublicKeyToken=8354ae6d2174ddca, processorArchitecture=MSIL">
       <HintPath>..\packages\iTextSharp.5.5.13\lib\itextsharp.dll</HintPath>
     </Reference>
-    <Reference Include="ManagedThermoHelperLayer, Version=1.0.426.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\mzLib.1.0.426\lib\net471\ManagedThermoHelperLayer.dll</HintPath>
+    <Reference Include="ManagedThermoHelperLayer, Version=1.0.428.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\packages\mzLib.1.0.428\lib\net471\ManagedThermoHelperLayer.dll</HintPath>
     </Reference>
     <Reference Include="MassSpectrometry, Version=1.0.0.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\mzLib.1.0.426\lib\net471\MassSpectrometry.dll</HintPath>
+      <HintPath>..\packages\mzLib.1.0.428\lib\net471\MassSpectrometry.dll</HintPath>
     </Reference>
     <Reference Include="MathNet.Numerics, Version=4.5.1.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\MathNet.Numerics.4.5.1\lib\net461\MathNet.Numerics.dll</HintPath>
     </Reference>
     <Reference Include="Mgf, Version=1.0.0.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\mzLib.1.0.426\lib\net471\Mgf.dll</HintPath>
+      <HintPath>..\packages\mzLib.1.0.428\lib\net471\Mgf.dll</HintPath>
     </Reference>
     <Reference Include="MzIdentML, Version=1.0.0.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\mzLib.1.0.426\lib\net471\MzIdentML.dll</HintPath>
+      <HintPath>..\packages\mzLib.1.0.428\lib\net471\MzIdentML.dll</HintPath>
     </Reference>
     <Reference Include="MzLibUtil, Version=1.0.0.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\mzLib.1.0.426\lib\net471\MzLibUtil.dll</HintPath>
+      <HintPath>..\packages\mzLib.1.0.428\lib\net471\MzLibUtil.dll</HintPath>
     </Reference>
     <Reference Include="MzML, Version=1.0.0.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\mzLib.1.0.426\lib\net471\MzML.dll</HintPath>
+      <HintPath>..\packages\mzLib.1.0.428\lib\net471\MzML.dll</HintPath>
     </Reference>
     <Reference Include="Nett, Version=0.8.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Nett.0.8.0\lib\Net40\Nett.dll</HintPath>
@@ -117,10 +117,10 @@
       <HintPath>..\packages\OxyPlot.Wpf.1.0.0\lib\net45\OxyPlot.Wpf.dll</HintPath>
     </Reference>
     <Reference Include="PepXML, Version=1.0.0.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\mzLib.1.0.426\lib\net471\PepXML.dll</HintPath>
+      <HintPath>..\packages\mzLib.1.0.428\lib\net471\PepXML.dll</HintPath>
     </Reference>
     <Reference Include="Proteomics, Version=1.0.0.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\mzLib.1.0.426\lib\net471\Proteomics.dll</HintPath>
+      <HintPath>..\packages\mzLib.1.0.428\lib\net471\Proteomics.dll</HintPath>
     </Reference>
     <Reference Include="SharpLearning.Common.Interfaces, Version=0.26.9.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SharpLearning.Common.Interfaces.0.26.9\lib\net461\SharpLearning.Common.Interfaces.dll</HintPath>
@@ -150,7 +150,7 @@
       <HintPath>..\packages\SharpLearning.RandomForest.0.26.9\lib\net461\SharpLearning.RandomForest.dll</HintPath>
     </Reference>
     <Reference Include="Spectra, Version=1.0.0.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\mzLib.1.0.426\lib\net471\Spectra.dll</HintPath>
+      <HintPath>..\packages\mzLib.1.0.428\lib\net471\Spectra.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -166,11 +166,11 @@
       <RequiredTargetFramework>4.0</RequiredTargetFramework>
     </Reference>
     <Reference Include="System.Xml" />
-    <Reference Include="Thermo, Version=1.0.426.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\mzLib.1.0.426\lib\net471\Thermo.dll</HintPath>
+    <Reference Include="Thermo, Version=1.0.428.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\packages\mzLib.1.0.428\lib\net471\Thermo.dll</HintPath>
     </Reference>
     <Reference Include="UsefulProteomicsDatabases, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\mzLib.1.0.426\lib\net471\UsefulProteomicsDatabases.dll</HintPath>
+      <HintPath>..\packages\mzLib.1.0.428\lib\net471\UsefulProteomicsDatabases.dll</HintPath>
     </Reference>
     <Reference Include="WindowsBase" />
     <Reference Include="PresentationCore" />
@@ -427,8 +427,8 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\MathNet.Numerics.MKL.Win.2.2.0\build\MathNet.Numerics.MKL.Win.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MathNet.Numerics.MKL.Win.2.2.0\build\MathNet.Numerics.MKL.Win.targets'))" />
-    <Error Condition="!Exists('..\packages\mzLib.1.0.426\build\net471\mzLib.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\mzLib.1.0.426\build\net471\mzLib.targets'))" />
+    <Error Condition="!Exists('..\packages\mzLib.1.0.428\build\net471\mzLib.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\mzLib.1.0.428\build\net471\mzLib.targets'))" />
   </Target>
   <Import Project="..\packages\MathNet.Numerics.MKL.Win.2.2.0\build\MathNet.Numerics.MKL.Win.targets" Condition="Exists('..\packages\MathNet.Numerics.MKL.Win.2.2.0\build\MathNet.Numerics.MKL.Win.targets')" />
-  <Import Project="..\packages\mzLib.1.0.426\build\net471\mzLib.targets" Condition="Exists('..\packages\mzLib.1.0.426\build\net471\mzLib.targets')" />
+  <Import Project="..\packages\mzLib.1.0.428\build\net471\mzLib.targets" Condition="Exists('..\packages\mzLib.1.0.428\build\net471\mzLib.targets')" />
 </Project>

--- a/GUI/packages.config
+++ b/GUI/packages.config
@@ -3,7 +3,7 @@
   <package id="iTextSharp" version="5.5.13" targetFramework="net471" />
   <package id="MathNet.Numerics" version="4.5.1" targetFramework="net471" />
   <package id="MathNet.Numerics.MKL.Win" version="2.2.0" targetFramework="net471" />
-  <package id="mzLib" version="1.0.426" targetFramework="net471" />
+  <package id="mzLib" version="1.0.428" targetFramework="net471" />
   <package id="Nett" version="0.8.0" targetFramework="net471" />
   <package id="Newtonsoft.Json" version="11.0.1" targetFramework="net471" />
   <package id="OxyPlot.Core" version="1.0.0" targetFramework="net471" />

--- a/TaskLayer/TaskLayer.csproj
+++ b/TaskLayer/TaskLayer.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="MathNet.Numerics" Version="4.5.1" />
-    <PackageReference Include="mzLib" Version="1.0.426" />
+    <PackageReference Include="mzLib" Version="1.0.428" />
     <PackageReference Include="NetSerializer" Version="4.1.0" />
     <PackageReference Include="Nett" Version="0.8.0" />
     <PackageReference Include="SharpLearning.Common.Interfaces" Version="0.26.9" />

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="FluentCommandLineParser" Version="1.4.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="mzLib" Version="1.0.426" />
+    <PackageReference Include="mzLib" Version="1.0.428" />
     <PackageReference Include="NUnit" Version="3.11.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.11.2" />
     <PackageReference Include="OxyPlot.Core" Version="1.0.0" />


### PR DESCRIPTION
* Fix SNES bug effecting all SNES searches for peptides with the precursor that's equal to the observed and the minimum peptide length

* Update mzlib